### PR TITLE
40 : Add keycloak authentication in jpa server starter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 
         <dependency>
             <groupId>org.smartregister</groupId>
-            <artifactId>hapi-fhir-opensrp-security-config</artifactId>
+            <artifactId>hapi-fhir-keycloak</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -127,11 +127,17 @@
             <classifier>classes</classifier>
         </dependency>
 
+<!--        <dependency>-->
+<!--            <groupId>ca.uhn.hapi.fhir</groupId>-->
+<!--            <artifactId>hapi-fhir-opensrp-security-config</artifactId>-->
+<!--            <version>0.0.1-PRE5-SNAPSHOT</version>-->
+<!--        </dependency>-->
         <dependency>
-            <groupId>ca.uhn.hapi.fhir</groupId>
+            <groupId>org.smartregister</groupId>
             <artifactId>hapi-fhir-opensrp-security-config</artifactId>
-            <version>0.0.1-PRE5-SNAPSHOT</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
+
 
         <!-- HAPI-FHIR uses Logback for logging support. The logback library is included automatically by Maven as a part of the hapi-fhir-base dependency, but you also need to include a logging library. Logback
             is used here, but log4j would also be fine. -->

--- a/pom.xml
+++ b/pom.xml
@@ -127,17 +127,11 @@
             <classifier>classes</classifier>
         </dependency>
 
-<!--        <dependency>-->
-<!--            <groupId>ca.uhn.hapi.fhir</groupId>-->
-<!--            <artifactId>hapi-fhir-opensrp-security-config</artifactId>-->
-<!--            <version>0.0.1-PRE5-SNAPSHOT</version>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.smartregister</groupId>
             <artifactId>hapi-fhir-opensrp-security-config</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
-
 
         <!-- HAPI-FHIR uses Logback for logging support. The logback library is included automatically by Maven as a part of the hapi-fhir-base dependency, but you also need to include a logging library. Logback
             is used here, but log4j would also be fine. -->

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-opensrp-security-config</artifactId>
-            <version>5.4.0-PRE5-SNAPSHOT</version>
+            <version>0.0.1-PRE5-SNAPSHOT</version>
         </dependency>
 
         <!-- HAPI-FHIR uses Logback for logging support. The logback library is included automatically by Maven as a part of the hapi-fhir-base dependency, but you also need to include a logging library. Logback

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-jpaserver-base</artifactId>
-            <version>5.4.1-PRE5-SNAPSHOT</version>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>
@@ -116,14 +116,14 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-testpage-overlay</artifactId>
-            <version>5.4.1-PRE5-SNAPSHOT</version>
+            <version>${project.version}</version>
             <type>war</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-testpage-overlay</artifactId>
-            <version>5.4.1-PRE5-SNAPSHOT</version>
+            <version>${project.version}</version>
             <classifier>classes</classifier>
         </dependency>
 
@@ -320,17 +320,7 @@
 
 
     </dependencies>
-<!--    <dependencyManagement>-->
-<!--        <dependencies>-->
-<!--    <dependency>-->
-<!--        <groupId>org.keycloak.bom</groupId>-->
-<!--        <artifactId>keycloak-adapter-bom</artifactId>-->
-<!--        <version>13.0.0</version>-->
-<!--        <type>pom</type>-->
-<!--        <scope>import</scope>-->
-<!--    </dependency>-->
-<!--</dependencies>-->
-<!--        </dependencyManagement>-->
+
     <build>
 
         <pluginManagement>
@@ -406,7 +396,6 @@
                         <overlay>
                             <groupId>ca.uhn.hapi.fhir</groupId>
                             <artifactId>hapi-fhir-testpage-overlay</artifactId>
-<!--                            <version>5.4.1-PRE5-SNAPSHOT</version>-->
                         </overlay>
                     </overlays>
                     <failOnMissingWebXml>false</failOnMissingWebXml>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-jpaserver-base</artifactId>
-            <version>${project.version}</version>
+            <version>5.4.1-PRE5-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>
@@ -116,15 +116,21 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-testpage-overlay</artifactId>
-            <version>${project.version}</version>
+            <version>5.4.1-PRE5-SNAPSHOT</version>
             <type>war</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-testpage-overlay</artifactId>
-            <version>${project.version}</version>
+            <version>5.4.1-PRE5-SNAPSHOT</version>
             <classifier>classes</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>ca.uhn.hapi.fhir</groupId>
+            <artifactId>hapi-fhir-opensrp-security-config</artifactId>
+            <version>5.4.0-PRE5-SNAPSHOT</version>
         </dependency>
 
         <!-- HAPI-FHIR uses Logback for logging support. The logback library is included automatically by Maven as a part of the hapi-fhir-base dependency, but you also need to include a logging library. Logback
@@ -314,7 +320,17 @@
 
 
     </dependencies>
-
+<!--    <dependencyManagement>-->
+<!--        <dependencies>-->
+<!--    <dependency>-->
+<!--        <groupId>org.keycloak.bom</groupId>-->
+<!--        <artifactId>keycloak-adapter-bom</artifactId>-->
+<!--        <version>13.0.0</version>-->
+<!--        <type>pom</type>-->
+<!--        <scope>import</scope>-->
+<!--    </dependency>-->
+<!--</dependencies>-->
+<!--        </dependencyManagement>-->
     <build>
 
         <pluginManagement>
@@ -390,6 +406,7 @@
                         <overlay>
                             <groupId>ca.uhn.hapi.fhir</groupId>
                             <artifactId>hapi-fhir-testpage-overlay</artifactId>
+<!--                            <version>5.4.1-PRE5-SNAPSHOT</version>-->
                         </overlay>
                     </overlays>
                     <failOnMissingWebXml>false</failOnMissingWebXml>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
@@ -1,5 +1,6 @@
 package ca.uhn.fhir.jpa.starter;
 
+import autoconfigure.KeycloakSecurityConfig;
 import ca.uhn.fhir.jpa.mdm.MdmConfig;
 import ca.uhn.fhir.jpa.starter.annotations.OnEitherVersion;
 import ca.uhn.fhir.jpa.subscription.channel.config.SubscriptionChannelConfig;
@@ -9,8 +10,12 @@ import ca.uhn.fhir.jpa.subscription.submit.config.SubscriptionSubmitterConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
@@ -25,6 +30,7 @@ import org.springframework.web.servlet.DispatcherServlet;
   JpaRestfulServer.class})
 @SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class})
 @Import({SubscriptionSubmitterConfig.class, SubscriptionProcessorConfig.class, SubscriptionChannelConfig.class, WebsocketDispatcherConfig.class, MdmConfig.class})
+@EnableAutoConfiguration(exclude = {ErrorMvcAutoConfiguration.class})
 public class Application extends SpringBootServletInitializer {
 
   public static void main(String[] args) {
@@ -52,7 +58,7 @@ public class Application extends SpringBootServletInitializer {
     JpaRestfulServer jpaRestfulServer = new JpaRestfulServer();
     beanFactory.autowireBean(jpaRestfulServer);
     servletRegistrationBean.setServlet(jpaRestfulServer);
-    servletRegistrationBean.addUrlMappings("/fhir/*");
+    servletRegistrationBean.addUrlMappings("/fhir/rest/*");
     servletRegistrationBean.setLoadOnStartup(1);
 
     return servletRegistrationBean;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
@@ -55,7 +55,7 @@ public class Application extends SpringBootServletInitializer {
     JpaRestfulServer jpaRestfulServer = new JpaRestfulServer();
     beanFactory.autowireBean(jpaRestfulServer);
     servletRegistrationBean.setServlet(jpaRestfulServer);
-    servletRegistrationBean.addUrlMappings("/fhir/rest/*");
+    servletRegistrationBean.addUrlMappings("/fhir/*");
     servletRegistrationBean.setLoadOnStartup(1);
 
     return servletRegistrationBean;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
@@ -1,6 +1,5 @@
 package ca.uhn.fhir.jpa.starter;
 
-import autoconfigure.KeycloakSecurityConfig;
 import ca.uhn.fhir.jpa.mdm.MdmConfig;
 import ca.uhn.fhir.jpa.starter.annotations.OnEitherVersion;
 import ca.uhn.fhir.jpa.subscription.channel.config.SubscriptionChannelConfig;
@@ -13,8 +12,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.ServletComponentScan;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/BaseJpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/BaseJpaRestfulServer.java
@@ -10,7 +10,7 @@ import ca.uhn.fhir.jpa.api.config.DaoConfig;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirSystemDao;
 import ca.uhn.fhir.jpa.binstore.BinaryStorageInterceptor;
-import ca.uhn.fhir.jpa.bulk.provider.BulkDataExportProvider;
+import ca.uhn.fhir.jpa.bulk.export.provider.BulkDataExportProvider;
 import ca.uhn.fhir.jpa.interceptor.CascadingDeleteInterceptor;
 import ca.uhn.fhir.jpa.packages.IPackageInstallerSvc;
 import ca.uhn.fhir.jpa.packages.PackageInstallationSpec;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/BaseJpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/BaseJpaRestfulServer.java
@@ -10,7 +10,7 @@ import ca.uhn.fhir.jpa.api.config.DaoConfig;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirSystemDao;
 import ca.uhn.fhir.jpa.binstore.BinaryStorageInterceptor;
-import ca.uhn.fhir.jpa.bulk.export.provider.BulkDataExportProvider;
+import ca.uhn.fhir.jpa.bulk.provider.BulkDataExportProvider;
 import ca.uhn.fhir.jpa.interceptor.CascadingDeleteInterceptor;
 import ca.uhn.fhir.jpa.packages.IPackageInstallerSvc;
 import ca.uhn.fhir.jpa.packages.PackageInstallationSpec;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -112,7 +112,7 @@ hapi:
     tester:
         home:
           name: Local Tester
-          server_address: 'http://localhost:8080/fhir/rest'
+          server_address: 'http://localhost:8080/fhir'
           refuse_to_fetch_third_party_urls: false
           fhir_version: R4
         global:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,10 +1,12 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
-    url: 'jdbc:h2:file:./target/database/h2'
+    url: 'jdbc:postgresql://localhost:5432/hapi_fhir'
     #url: jdbc:h2:mem:test_mem
-    username: sa
-    password: null
-    driverClassName: org.h2.Driver
+    username: postgres
+    password: root
+    driverClassName: org.postgresql.Driver
     max-active: 15
 
     # database connection pool size
@@ -110,7 +112,7 @@ hapi:
     tester:
         home:
           name: Local Tester
-          server_address: 'http://localhost:8080/fhir'
+          server_address: 'http://localhost:8080/fhir/rest'
           refuse_to_fetch_third_party_urls: false
           fhir_version: R4
         global:
@@ -153,3 +155,15 @@ hapi:
 #  protocol: 'http'
 #  schema_management_strategy: CREATE
 #  username: SomeUsername
+#security:
+#  ignored: none
+keycloak:
+  auth-server-url: https://cc3ddc230510.ngrok.io/auth/
+  realm: fhir-core
+  resource: fhir-core-server
+  credentials:
+    secret: b7747a19-f72f-4906-8892-8438ce2492be
+  ssl-required: external
+#  use-resource-role-mappings: true,
+logging.level.org.springframework.web: trace
+logging.level.org.apache: trace

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -158,7 +158,7 @@ hapi:
 #security:
 #  ignored: none
 keycloak:
-  auth-server-url: https://cc3ddc230510.ngrok.io/auth/
+  auth-server-url: http://localhost:8180/auth/
   realm: fhir-core
   resource: fhir-core-server
   credentials:


### PR DESCRIPTION
https://github.com/OpenSRP/fhircore/issues/40

To build:

1. Update keycloak details from the stage Keycloak server in application.yml
2. Add `http://localhost:8080/*` as a redirect URL on the stage Keycloak server for this realm and client
3. Build `hapi-fhir-opensrp-security-config` package from the `hapi-fhir` repo (Reference [PR](https://github.com/opensrp/hapi-fhir/pull/1))
4. Build and run `jpa-server-starter` project using `Pboot` profile. Deploy on Tomcat server.
5. Visit http://localhost:8080/fhir/rest/Patient/1 on your browser. This should currently redirect to the Keycloak login page. The valid response is returned with a status code of 200 when the correct login credentials are entered.
6. Visit http://localhost:8080/fhir/rest/Patient/1 on Postman with the correct Oauth token to fetch the response. 

Please note : Authentication in test-page-overlay (web UI) is not a part of this PR.