### PR TITLE
Upgrade HAPI FHIR Extensions dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,10 @@
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>
 
     <groupId>org.smartregister</groupId>
-    <version>6.1.5-SNAPSHOT</version>
+    <version>6.1.6-SNAPSHOT</version>
     
     <properties>
-        <hapi.fhir.version>6.1.0</hapi.fhir.version>
+        <hapi.fhir.version>6.1.1</hapi.fhir.version>
         <spring_boot_version>2.5.6</spring_boot_version>
         <java.version>11</java.version>
     </properties>
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>org.smartregister.hapi-fhir-opensrp-extensions</groupId>
             <artifactId>location</artifactId>
-            <version>0.0.8-SNAPSHOT</version>
+            <version>0.0.9-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>
 
     <groupId>org.smartregister</groupId>
-    <version>6.1.6-SNAPSHOT</version>
+    <version>6.1.7-SNAPSHOT</version>
     
     <properties>
         <hapi.fhir.version>6.1.1</hapi.fhir.version>
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>org.smartregister.hapi-fhir-opensrp-extensions</groupId>
             <artifactId>practitioner</artifactId>
-            <version>0.0.12-SNAPSHOT</version>
+            <version>0.0.13-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-        <version>6.1.1</version>
+        <version>6.1.3</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>
@@ -23,7 +23,7 @@
     <version>6.1.7-SNAPSHOT</version>
     
     <properties>
-        <hapi.fhir.version>6.1.1</hapi.fhir.version>
+        <hapi.fhir.version>6.1.3</hapi.fhir.version>
         <spring_boot_version>2.5.6</spring_boot_version>
         <java.version>11</java.version>
     </properties>


### PR DESCRIPTION

- Upgrade HAPI FHIR Extension dependencies
  - Locations to 0.0.9-SNAPSHOT
  - Practitioner to 0.0.13-SNAPSHOT

- Upgrade HAPI FHIR version to 6.1.3